### PR TITLE
DecodeAddress fix for ltc mainnet

### DIFF
--- a/appdata_test.go
+++ b/appdata_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"unicode"
 
-	"github.com/btcsuite/btcutil"
+	"github.com/sparkswap/btcutil"
 )
 
 // TestAppDataDir tests the API for AppDataDir to ensure it gives expected

--- a/block_test.go
+++ b/block_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/sparkswap/btcutil"
 )
 
 // TestBlock tests the API for Block.


### PR DESCRIPTION
This PR updated DecodeAddress to use `chaincfg` params that were passed into the function instead of default params from btc chaincfg.

LND uses the DecodeAddress function for bitcoin AND litecoin, where litecoin's mainnet chaincfg deviates from btc's chaincfg. This function is currently broken for Litecoin mainnet.

This is a quick fix for mainnet as we try to provide a better solution (since having logic for litecoin in btcutil is not ideal... see tests)